### PR TITLE
Add Whisper MLX support for Apple Silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__/
 *.class
 .venv/
 uv.lock
+
+# Locally downloaded models
+mlx_models/

--- a/.sample_env
+++ b/.sample_env
@@ -11,6 +11,7 @@ OPENAI_MODEL_NAME="whisper-1"
 # Uncomment and configure for local Whisper MLX (Apple Silicon only):
 # UTTERTYPE_PROVIDER="mlx"
 # MLX_MODEL_NAME="distil-medium.en"
+# HF_TOKEN="your-huggingface-token"  # Required to download models from HuggingFace
 
 # ===== Google Gemini API Settings =====
 # Uncomment and configure for Google Gemini API:

--- a/.sample_env
+++ b/.sample_env
@@ -1,4 +1,4 @@
-# Choose your transcription provider (openai, google or local)
+# Choose your transcription provider (openai, google or mlx)
 UTTERTYPE_PROVIDER="openai"
 
 # ===== OpenAI Whisper API Settings =====
@@ -7,10 +7,10 @@ OPENAI_API_KEY="sk-<your_key_here>"
 OPENAI_BASE_URL="https://api.openai.com/v1"
 OPENAI_MODEL_NAME="whisper-1"
 
-# ===== Local Whisper Server Settings =====
-# Uncomment and configure for local lightning_whisper_mlx:
-# OPENAI_MODEL_NAME="Systran/faster-distil-whisper-large-v3"
-# OPENAI_MODEL_NAME="deepdml/faster-whisper-large-v3-turbo-ct2"
+# ===== Apple MLX Whisper Settings =====
+# Uncomment and configure for local Whisper MLX (Apple Silicon only):
+# UTTERTYPE_PROVIDER="mlx"
+# MLX_MODEL_NAME="distil-medium.en"
 
 # ===== Google Gemini API Settings =====
 # Uncomment and configure for Google Gemini API:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Select the provider you want to use by setting the `UTTERTYPE_PROVIDER` environm
 # OpenAI Whisper (default)
 UTTERTYPE_PROVIDER="openai"
 
+# Apple Silicon MLX (local, Mac only)
+UTTERTYPE_PROVIDER="mlx"
+
 # Google Gemini
 UTTERTYPE_PROVIDER="google"
 ```
@@ -87,6 +90,11 @@ Create a `.env` file in the project directory with the settings for your chosen 
 OPENAI_API_KEY="sk-your-key-here"
 OPENAI_BASE_URL="https://api.openai.com/v1"  # optional
 OPENAI_MODEL_NAME="whisper-1"  # optional
+
+# For Apple Silicon MLX (local, Mac only):
+# UTTERTYPE_PROVIDER="mlx"
+# MLX_MODEL_NAME="distil-medium.en"  # optional
+# Note: Requires additional installation: pip install 'uttertype[mlx]'
 
 # For Google Gemini:
 GEMINI_API_KEY="your-api-key-here"  # For Gemini developer API
@@ -108,6 +116,13 @@ export UTTERTYPE_PROVIDER="openai"
 export OPENAI_API_KEY="sk-your-key-here"
 export OPENAI_BASE_URL="https://api.openai.com/v1"  # optional
 export OPENAI_MODEL_NAME="whisper-1"  # optional
+```
+
+For Apple Silicon MLX (Mac only):
+```shell
+export UTTERTYPE_PROVIDER="mlx"
+export MLX_MODEL_NAME="distil-medium.en"  # optional
+# Note: Requires additional installation: pip install 'uttertype[mlx]'
 ```
 
 For Gemini (Linux/macOS):
@@ -141,6 +156,22 @@ For faster and cheaper transcription, you can set up a local [faster-whisper-ser
    - `Systran/faster-whisper-small` (fastest)
    - `Systran/faster-distil-whisper-large-v3` (most accurate)
    - `deepdml/faster-whisper-large-v3-turbo-ct2` (almost as good, but faster)
+
+#### Using Apple Silicon MLX
+For the fastest local transcription on Apple Silicon Macs (M1/M2/M3):
+
+1. Install the MLX dependency:
+   ```shell
+   pip install 'uttertype[mlx]'
+   ```
+   
+2. Configure in your .env file:
+   ```env
+   UTTERTYPE_PROVIDER="mlx"
+   MLX_MODEL_NAME="distil-medium.en"  # optional
+   ```
+
+This option uses Apple's MLX framework to run Whisper models natively on the Neural Engine, providing very fast transcription without requiring an API key or internet connection.
 
 ### 5. Final run and permissions
 Finally, run the application using one of these methods:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ OPENAI_MODEL_NAME="whisper-1"  # optional
 # For Apple Silicon MLX (local, Mac only):
 # UTTERTYPE_PROVIDER="mlx"
 # MLX_MODEL_NAME="distil-medium.en"  # optional
-# Note: Requires additional installation: pip install 'uttertype[mlx]'
+# Note: Requires additional installation: uv sync --extra mlx
 
 # For Google Gemini:
 GEMINI_API_KEY="your-api-key-here"  # For Gemini developer API
@@ -122,7 +122,7 @@ For Apple Silicon MLX (Mac only):
 ```shell
 export UTTERTYPE_PROVIDER="mlx"
 export MLX_MODEL_NAME="distil-medium.en"  # optional
-# Note: Requires additional installation: pip install 'uttertype[mlx]'
+# Note: Requires additional installation: uv sync --extra mlx
 ```
 
 For Gemini (Linux/macOS):
@@ -162,7 +162,7 @@ For the fastest local transcription on Apple Silicon Macs (M1/M2/M3):
 
 1. Install the MLX dependency:
    ```shell
-   pip install 'uttertype[mlx]'
+   uv sync --extra mlx
    ```
    
 2. Configure in your .env file:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ OPENAI_MODEL_NAME="whisper-1"  # optional
 # For Apple Silicon MLX (local, Mac only):
 # UTTERTYPE_PROVIDER="mlx"
 # MLX_MODEL_NAME="distil-medium.en"  # optional
+# HF_TOKEN="your-huggingface-token"  # Required to download models from HuggingFace
 # Note: Requires additional installation: uv sync --extra mlx
 
 # For Google Gemini:
@@ -122,6 +123,7 @@ For Apple Silicon MLX (Mac only):
 ```shell
 export UTTERTYPE_PROVIDER="mlx"
 export MLX_MODEL_NAME="distil-medium.en"  # optional
+export HF_TOKEN="your-huggingface-token"  # Required to download models
 # Note: Requires additional installation: uv sync --extra mlx
 ```
 
@@ -169,7 +171,10 @@ For the fastest local transcription on Apple Silicon Macs (M1/M2/M3):
    ```env
    UTTERTYPE_PROVIDER="mlx"
    MLX_MODEL_NAME="distil-medium.en"  # optional
+   HF_TOKEN="your-huggingface-token"  # Required to download models
    ```
+   
+   Note: You'll need a HuggingFace token to download the models. You can get one by creating a free account at [huggingface.co](https://huggingface.co/join).
 
 This option uses Apple's MLX framework to run Whisper models natively on the Neural Engine, providing very fast transcription without requiring an API key or internet connection.
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,15 @@ For the fastest local transcription on Apple Silicon Macs (M1/M2/M3):
    
    Note: You'll need a HuggingFace token to download the models. You can get one by creating a free account at [huggingface.co](https://huggingface.co/join).
 
-This option uses Apple's MLX framework to run Whisper models natively on the Neural Engine, providing very fast transcription without requiring an API key or internet connection.
+This option uses [lightning-whisper-mlx](https://github.com/mustafaaljadery/lightning-whisper-mlx) with Apple's MLX framework to run Whisper models natively on the Neural Engine, providing very fast transcription without requiring an OpenAI API key.
+
+Available models for `MLX_MODEL_NAME` include:
+- `base.en` - Small, English-only model (fastest)
+- `small.en` - Better accuracy, English-only
+- `medium.en` - High accuracy, English-only
+- `distil-small.en` - Distilled version of small.en
+- `distil-medium.en` - Distilled version of medium.en (good balance of speed/accuracy)
+- `large-v2` - Most accurate, supports multiple languages
 
 ### 5. Final run and permissions
 Finally, run the application using one of these methods:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
     "google-genai",
 ]
 
+[project.optional-dependencies]
+mlx = ["lightning-whisper-mlx"]
+
 [project.scripts]
 uttertype = "uttertype.main:run_app"
 

--- a/uttertype/main.py
+++ b/uttertype/main.py
@@ -4,7 +4,7 @@ load_dotenv()  # Load environment variables up front
 import asyncio
 import os
 from pynput import keyboard
-from uttertype.transcriber import WhisperAPITranscriber, GeminiTranscriber
+from uttertype.transcriber import WhisperAPITranscriber, GeminiTranscriber, WhisperLocalMLXTranscriber
 from uttertype.table_interface import ConsoleTable
 from uttertype.key_listener import create_keylistener
 from uttertype.utils import manual_type
@@ -17,6 +17,8 @@ async def main():
         transcriber = GeminiTranscriber.create()
     elif transcriber_provider == 'openai':
         transcriber = WhisperAPITranscriber.create()
+    elif transcriber_provider == 'mlx':
+        transcriber = WhisperLocalMLXTranscriber.create()
     else:
         raise ValueError(f'Invalid transcriber provider: {transcriber_provider}')
 

--- a/uttertype/transcriber.py
+++ b/uttertype/transcriber.py
@@ -169,9 +169,18 @@ class WhisperAPITranscriber(AudioTranscriber):
 class WhisperLocalMLXTranscriber(AudioTranscriber):
     def __init__(self, model_type="distil-medium.en", *args, **kwargs):
         super().__init__(*args, **kwargs)
-        from lightning_whisper_mlx import LightningWhisperMLX
-
-        self.model = LightningWhisperMLX(model_type)
+        try:
+            from lightning_whisper_mlx import LightningWhisperMLX
+            self.model = LightningWhisperMLX(model_type)
+        except ImportError:
+            raise ImportError(
+                "lightning-whisper-mlx not found. Install with: pip install 'uttertype[mlx]'"
+            )
+    
+    @staticmethod
+    def create(*args, **kwargs):
+        model_type = os.getenv('MLX_MODEL_NAME', 'distil-medium.en')
+        return WhisperLocalMLXTranscriber(model_type=model_type)
 
     def transcribe_audio(self, audio: io.BytesIO) -> str:
         try:

--- a/uttertype/transcriber.py
+++ b/uttertype/transcriber.py
@@ -174,7 +174,7 @@ class WhisperLocalMLXTranscriber(AudioTranscriber):
             self.model = LightningWhisperMLX(model_type)
         except ImportError:
             raise ImportError(
-                "lightning-whisper-mlx not found. Install with: pip install 'uttertype[mlx]'"
+                "lightning-whisper-mlx not found. Install with: uv sync --extra mlx"
             )
     
     @staticmethod


### PR DESCRIPTION
## Summary
- Add native Apple Silicon support via Whisper MLX
- Makes transcription work locally without requiring API keys
- Configured through MLX_MODEL_NAME environment variable
- Added as optional dependency to avoid installation on non-Apple devices

## Test plan
- Install optional MLX dependency: `pip install 'uttertype[mlx]'`
- Configure by setting `UTTERTYPE_PROVIDER="mlx"` in .env file
- Optional: customize model with `MLX_MODEL_NAME="distil-medium.en"`
- Run the application and verify transcription works locally

🤖 Generated with Claude Code