### PR TITLE
Update PortAudio installation instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ### 1. [Install PortAudio/PyAudio](https://people.csail.mit.edu/hubert/pyaudio/)
 #### macOS
-Installing portaudio on macOS can be somewhat tricky, especially on M1+ chips. In general, using conda seems to be the safest way to install portaudio
+Installing portaudio on macOS can be somewhat tricky, especially on M1+ chips. The recommended way is to use Homebrew:
 ```
-conda install portaudio
+brew install portaudio
 ```
 #### Windows
 ```


### PR DESCRIPTION
## Summary
- Update macOS PortAudio installation instructions to use Homebrew instead of Conda
- This provides a more consistent installation experience, especially on Apple Silicon (M1+) Macs

## Test plan
- Verified that `brew install portaudio` successfully installs the required dependencies for PyAudio

🤖 Generated with Claude Code