### PR TITLE
Add minimum recording duration threshold feature

### DIFF
--- a/.sample_env
+++ b/.sample_env
@@ -27,3 +27,8 @@ OPENAI_MODEL_NAME="whisper-1"
 
 # UTTERTYPE_RECORD_HOTKEYS="<ctrl>+<alt>+v" # defaults to <globe> on Mac, <ctrl>+<alt>+v otherwise
 # See https://pynput.readthedocs.io/en/latest/keyboard.html#global-hotkeys for other options
+
+# Minimum recording duration in milliseconds (default: 500)
+# Recordings shorter than this will be ignored, useful for preventing
+# accidental transcriptions from quick hotkey presses
+# UTTERTYPE_MIN_RECORDING_MS=500

--- a/.sample_env
+++ b/.sample_env
@@ -28,7 +28,7 @@ OPENAI_MODEL_NAME="whisper-1"
 # UTTERTYPE_RECORD_HOTKEYS="<ctrl>+<alt>+v" # defaults to <globe> on Mac, <ctrl>+<alt>+v otherwise
 # See https://pynput.readthedocs.io/en/latest/keyboard.html#global-hotkeys for other options
 
-# Minimum recording duration in milliseconds (default: 500)
+# Minimum recording duration in milliseconds (default: 300)
 # Recordings shorter than this will be ignored, useful for preventing
 # accidental transcriptions from quick hotkey presses
-# UTTERTYPE_MIN_RECORDING_MS=500
+# UTTERTYPE_MIN_RECORDING_MS=300

--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ For Windows, use `$env:` instead of `export`.
 You can set a minimum duration threshold for recordings to prevent accidental transcriptions from quick hotkey presses:
 
 ```env
-# Set minimum recording duration to 500ms (default)
-UTTERTYPE_MIN_RECORDING_MS=500
+# Set minimum recording duration to 300ms (default)
+UTTERTYPE_MIN_RECORDING_MS=300
 ```
 
 This is useful if you want to use the hotkey button for other purposes when pressed quickly (i.e., not held down). Any recording shorter than this duration will be ignored.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ For Windows, use `$env:` instead of `export`.
 #### Advanced Configuration Options
 
 <details>
+<summary><b>Minimum Recording Duration</b></summary>
+
+You can set a minimum duration threshold for recordings to prevent accidental transcriptions from quick hotkey presses:
+
+```env
+# Set minimum recording duration to 500ms (default)
+UTTERTYPE_MIN_RECORDING_MS=500
+```
+
+This is useful if you want to use the hotkey button for other purposes when pressed quickly (i.e., not held down). Any recording shorter than this duration will be ignored.
+</details>
+
+<details>
 <summary><b>Google Vertex AI</b></summary>
 
 For enterprise Google Vertex AI integration:

--- a/uttertype/transcriber.py
+++ b/uttertype/transcriber.py
@@ -22,7 +22,7 @@ CHUNK = int(RATE * CHUNK_DURATION_MS / 1000)
 MIN_TRANSCRIPTION_SIZE_MS = 10000
 # Minimum duration of recording to process (in milliseconds)
 # Recordings shorter than this will be ignored (useful for accidental key presses)
-MIN_RECORDING_DURATION_MS = int(os.getenv('UTTERTYPE_MIN_RECORDING_MS', 500))
+MIN_RECORDING_DURATION_MS = int(os.getenv('UTTERTYPE_MIN_RECORDING_MS', 300))
 
 
 class AudioTranscriber:

--- a/uttertype/transcriber.py
+++ b/uttertype/transcriber.py
@@ -21,7 +21,8 @@ CHUNK = int(RATE * CHUNK_DURATION_MS / 1000)
 # Minimum duration of speech to send to API between gaps of silence (hard-coded to 10 seconds)
 MIN_TRANSCRIPTION_SIZE_MS = 10000
 # Minimum duration of recording to process (in milliseconds)
-# Recordings shorter than this will be ignored (useful for accidental key presses)
+# Recordings shorter than this will be ignored (useful for preventing
+# accidental transcriptions from quick hotkey presses)
 MIN_RECORDING_DURATION_MS = int(os.getenv('UTTERTYPE_MIN_RECORDING_MS', 300))
 
 

--- a/uttertype/transcriber.py
+++ b/uttertype/transcriber.py
@@ -20,6 +20,9 @@ CHUNK_DURATION_MS = 30  # Frame duration in milliseconds
 CHUNK = int(RATE * CHUNK_DURATION_MS / 1000)
 # Minimum duration of speech to send to API between gaps of silence (hard-coded to 10 seconds)
 MIN_TRANSCRIPTION_SIZE_MS = 10000
+# Minimum duration of recording to process (in milliseconds)
+# Recordings shorter than this will be ignored (useful for accidental key presses)
+MIN_RECORDING_DURATION_MS = int(os.getenv('UTTERTYPE_MIN_RECORDING_MS', 500))
 
 
 class AudioTranscriber:
@@ -79,6 +82,16 @@ class AudioTranscriber:
     def stop_recording(self):
         """Stop the recording and reset variables"""
         self.recording_finished.set()
+        
+        # Skip processing if recording is too short (e.g., accidental key press)
+        if self.audio_duration < MIN_RECORDING_DURATION_MS:
+            # Reset variables without processing
+            self.frames = []
+            self.audio_duration = 0
+            self.rolling_requests = []
+            self.rolling_transcriptions = []
+            return
+            
         self._finish_transcription()
         self.frames = []
         self.audio_duration = 0


### PR DESCRIPTION
- Add configurable UTTERTYPE_MIN_RECORDING_MS environment variable (default: 500ms)
- Skip processing recordings shorter than the threshold
- Update documentation in README and .sample_env
- Useful for preventing accidental transcriptions from quick key presses

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>