### PR TITLE
Unify HoldHotKey and HoldGlobeKey into single class

### DIFF
--- a/uttertype/key_listener.py
+++ b/uttertype/key_listener.py
@@ -8,7 +8,8 @@ class UnifiedHotKey(HotKey):
     A unified hotkey handler that works with both standard hotkeys and the macOS globe key.
     
     This class inherits from pynput's HotKey but adds hold functionality and
-    special handling for the macOS globe key.
+    special handling for the macOS globe key. The globe key only gets the release
+    trigger and not the press trigger.
     """
     
     # Globe key virtual key code (macOS)
@@ -16,49 +17,26 @@ class UnifiedHotKey(HotKey):
     
     def __init__(
         self, 
-        keys=None, 
+        keys,
         on_activate=lambda: None,
         on_deactivate=lambda: None,
         on_other_key=lambda: None,
-        is_globe_key=False
     ):
-        self.active = False
-        self._is_globe_key = is_globe_key
+        self._on_activate = on_activate
         self._on_deactivate = on_deactivate
         self._on_other_key = on_other_key
-        self._raw_on_activate = on_activate
-        
-        # Set up activation function
-        def _mod_on_activate():
-            self.active = True
-            self._raw_on_activate()
-            
-        # For globe key, we don't use the standard hotkey keys
-        # but we still inherit from HotKey for consistency
-        if is_globe_key:
-            # Initialize with empty key set
-            super().__init__(set(), _mod_on_activate)
-        else:
-            super().__init__(keys, _mod_on_activate)
-    
+
+        self._globe_key_pressed = False
+
+        super().__init__(keys, self._on_activate)
+
+    @property
+    def active(self):
+        # The hot key is active when all of the `_keys` are pressed (represented by `_state`)
+        return self._state == self._keys
+
     def press(self, key):
-        # Globe key special handling
-        if self._is_globe_key:
-            if hasattr(key, "vk") and key.vk == self.GLOBE_KEY_VK:
-                if self.active:  # hold ended
-                    self.active = False
-                    self._on_deactivate()
-                else:  # hold started
-                    self.active = True
-                    self._raw_on_activate()
-                
-            # Some other key was pressed while the globe key is held
-            elif self.active and getattr(key, "vk", 0) != self.GLOBE_KEY_VK:
-                self._on_other_key()
-            return
-            
-        # Standard hotkey handling
-        # Check if another key is being pressed during active hotkey
+        # If the hot-key is active, but another key was pressed
         if self.active and key not in self._keys:
             self._on_other_key()
             
@@ -66,19 +44,21 @@ class UnifiedHotKey(HotKey):
         super().press(key)
         
     def release(self, key):
-        # Globe key special handling (press and release are mixed)
-        if self._is_globe_key:
-            if hasattr(key, "vk") and key.vk == self.GLOBE_KEY_VK:
+        # Globe key special handling since it only gets the release trigger
+        if getattr(key, "vk", 0) == self.GLOBE_KEY_VK:
+            # It is not pressed yet, so send the `press signal` and exit
+            if not self._globe_key_pressed:
+                self._globe_key_pressed = True
                 self.press(key)
-            return
-            
+                return
+            else:
+                self._globe_key_pressed = False
+
         # Standard hotkey handling
         super().release(key)
         
-        # The `self._state != self._keys` happens when at least
-        # one of the hot-keys is no longer pressed
-        if self.active and self._state != self._keys:
-            self.active = False
+        # Because of the release, the hot-key may become no longer active
+        if not self.active:
             self._on_deactivate()
 
 
@@ -88,14 +68,9 @@ def create_keylistener(transcriber):
         "<globe>" if sys.platform == "darwin" else "<ctrl>+<alt>+v"
     )
 
-    # The globe key needs special hot-key handling
-    if key_code == "<globe>":
-        return UnifiedHotKey(
-            on_activate=transcriber.start_recording,
-            on_deactivate=transcriber.stop_recording,
-            on_other_key=transcriber.cancel_recording,
-            is_globe_key=True
-        )
+    # Convert the globe key to its virtual key code
+    if '<globe>' in key_code:
+        key_code = key_code.replace('<globe>', '<63>')
 
     return UnifiedHotKey(
         UnifiedHotKey.parse(key_code),

--- a/uttertype/key_listener.py
+++ b/uttertype/key_listener.py
@@ -3,70 +3,83 @@ import sys
 from pynput.keyboard import HotKey
 
 
-class HoldHotKey(HotKey):
-    def __init__(self, keys, on_activate, on_deactivate, on_other_key):
+class UnifiedHotKey(HotKey):
+    """
+    A unified hotkey handler that works with both standard hotkeys and the macOS globe key.
+    
+    This class inherits from pynput's HotKey but adds hold functionality and
+    special handling for the macOS globe key.
+    """
+    
+    # Globe key virtual key code (macOS)
+    GLOBE_KEY_VK = 63
+    
+    def __init__(
+        self, 
+        keys=None, 
+        on_activate=lambda: None,
+        on_deactivate=lambda: None,
+        on_other_key=lambda: None,
+        is_globe_key=False
+    ):
         self.active = False
-
+        self._is_globe_key = is_globe_key
+        self._on_deactivate = on_deactivate
+        self._on_other_key = on_other_key
+        self._raw_on_activate = on_activate
+        
+        # Set up activation function
         def _mod_on_activate():
             self.active = True
-            on_activate()
-
-        def _mod_on_deactivate():
-            self.active = False
-            on_deactivate()
-
-        super().__init__(keys, _mod_on_activate)
-        self._on_deactivate = _mod_on_deactivate
-        self._on_other_key = on_other_key
-
+            self._raw_on_activate()
+            
+        # For globe key, we don't use the standard hotkey keys
+        # but we still inherit from HotKey for consistency
+        if is_globe_key:
+            # Initialize with empty key set
+            super().__init__(set(), _mod_on_activate)
+        else:
+            super().__init__(keys, _mod_on_activate)
+    
     def press(self, key):
-        # Check if the hotkey is active and another key is being pressed
+        # Globe key special handling
+        if self._is_globe_key:
+            if hasattr(key, "vk") and key.vk == self.GLOBE_KEY_VK:
+                if self.active:  # hold ended
+                    self.active = False
+                    self._on_deactivate()
+                else:  # hold started
+                    self.active = True
+                    self._raw_on_activate()
+                
+            # Some other key was pressed while the globe key is held
+            elif self.active and getattr(key, "vk", 0) != self.GLOBE_KEY_VK:
+                self._on_other_key()
+            return
+            
+        # Standard hotkey handling
+        # Check if another key is being pressed during active hotkey
         if self.active and key not in self._keys:
-            # Another key was pressed during recording, cancel it
             self._on_other_key()
-        
+            
         # Continue with normal processing
         super().press(key)
-
+        
     def release(self, key):
+        # Globe key special handling (press and release are mixed)
+        if self._is_globe_key:
+            if hasattr(key, "vk") and key.vk == self.GLOBE_KEY_VK:
+                self.press(key)
+            return
+            
+        # Standard hotkey handling
         super().release(key)
+        
         # The `self._state != self._keys` happens when at least
         # one of the hot-keys is no longer pressed
         if self.active and self._state != self._keys:
+            self.active = False
             self._on_deactivate()
-
-
-class HoldGlobeKey:
-    """
-    For macOS only, globe key requires special handling.
-
-    Specifically, it only triggers the `release` event.
-    """
-
-    def __init__(self, on_activate, on_deactivate, on_other_key):
-        self.held = False
-        self._on_activate = on_activate
-        self._on_deactivate = on_deactivate
-        self._on_other_key = on_other_key
-
-    def press(self, key):
-        if hasattr(key, "vk"):
-            if key.vk == 63:  # Globe key
-                if self.held:  # hold ended
-                    self._on_deactivate()
-                else:  # hold started
-                    self._on_activate()
-                self.held = not self.held
-
-        # Some other key was pressed while the globe key is held
-        if self.held and getattr(key, "vk", 0) != 63:
-            self._on_other_key()
-
-    def release(self, key):
-        """Press and release signals are mixed for globe key"""
-        # For globe key, handle via press
-        if hasattr(key, "vk") and key.vk == 63:
-            self.press(key)
 
 
 def create_keylistener(transcriber):
@@ -77,15 +90,16 @@ def create_keylistener(transcriber):
 
     # The globe key needs special hot-key handling
     if key_code == "<globe>":
-        return HoldGlobeKey(
+        return UnifiedHotKey(
             on_activate=transcriber.start_recording,
             on_deactivate=transcriber.stop_recording,
             on_other_key=transcriber.cancel_recording,
+            is_globe_key=True
         )
 
-    return HoldHotKey(
-          HoldHotKey.parse(key_code),
-          on_activate=transcriber.start_recording,
-          on_deactivate=transcriber.stop_recording,
-          on_other_key=transcriber.cancel_recording,
-      )
+    return UnifiedHotKey(
+        UnifiedHotKey.parse(key_code),
+        on_activate=transcriber.start_recording,
+        on_deactivate=transcriber.stop_recording,
+        on_other_key=transcriber.cancel_recording
+    )


### PR DESCRIPTION
Created a unified UnifiedHotKey class that inherits from pynput's HotKey
and handles both standard hotkeys and the macOS globe key. This improves
maintainability while preserving all existing functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>