### PR TITLE
Only use microphone when hotkey is active

### DIFF
--- a/uttertype/main.py
+++ b/uttertype/main.py
@@ -24,15 +24,25 @@ async def main():
 
     hotkey = create_keylistener(transcriber)
 
-    keyboard.Listener(on_press=hotkey.press, on_release=hotkey.release).start()
-    console_table = ConsoleTable()
-    with console_table:
-        async for transcription, audio_duration_ms in transcriber.get_transcriptions():
-            manual_type(transcription.strip())
-            console_table.insert(
-                transcription,
-                round(0.0001 * audio_duration_ms / 1000, 6),
-            )
+    keyboard_listener = keyboard.Listener(on_press=hotkey.press, on_release=hotkey.release)
+    keyboard_listener.start()
+    
+    try:
+        console_table = ConsoleTable()
+        with console_table:
+            async for transcription, audio_duration_ms in transcriber.get_transcriptions():
+                manual_type(transcription)
+                console_table.insert(
+                    transcription,
+                    round(0.0001 * audio_duration_ms / 1000, 6),
+                )
+    except KeyboardInterrupt:
+        # Handle Ctrl+C gracefully
+        pass
+    finally:
+        # Clean up resources
+        keyboard_listener.stop()
+        transcriber.cleanup()
 
 
 def run_app():

--- a/uttertype/utils.py
+++ b/uttertype/utils.py
@@ -36,4 +36,4 @@ def manual_type(text: str, delay: float = 0.0042):
 
 
 def transcription_concat(transcriptions: List[str]) -> str:
-    return " ".join([t.strip() for t in transcriptions])  # Simple concat for now
+    return " ".join([t.strip() for t in transcriptions]).strip()  # Simple concat for now


### PR DESCRIPTION
## Summary
- Modified AudioTranscriber to only open the microphone stream when hotkey is active
- Added proper stream cleanup when recording stops
- Added resource management with try/finally blocks and explicit cleanup
- Improved error handling for graceful application shutdown

## Test plan
- Run the application and verify that the microphone is only accessed when hotkey is pressed
- Check that all resources are properly released when the application exits
- Verify that the application handles Ctrl+C gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)