### PR TITLE
Add context screenshot functionality for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,15 +270,10 @@ Available models with speed/accuracy tradeoffs:
 
 UtterType can capture screenshots of the active window on macOS for context-aware transcription:
 
-1. Install the macOS-specific dependencies:
-   ```bash
-   uv sync --extra macos
-   ```
-   
-2. This enables the `capture_active_window()` function in `context_screenshot.py` which:
-   - Returns a PIL Image of the currently active window
-   - Returns None on non-macOS platforms or if dependencies are missing
-   - Uses mss for screen capture and Pillow for image processing
+Install the macOS-specific dependencies:
+```bash
+uv sync --extra macos
+```
 
 The screenshot functionality can be useful for providing visual context in context-aware transcription scenarios.
 </details>

--- a/README.md
+++ b/README.md
@@ -265,6 +265,24 @@ Available models with speed/accuracy tradeoffs:
 | `large-v2` | Extra large | Multilingual | ★★ | ★★★★★ |
 </details>
 
+<details>
+<summary><b>macOS Context Screenshot</b></summary>
+
+UtterType can capture screenshots of the active window on macOS for context-aware transcription:
+
+1. Install the macOS-specific dependencies:
+   ```bash
+   uv sync --extra macos
+   ```
+   
+2. This enables the `capture_active_window()` function in `context_screenshot.py` which:
+   - Returns a PIL Image of the currently active window
+   - Returns None on non-macOS platforms or if dependencies are missing
+   - Uses mss for screen capture and Pillow for image processing
+
+The screenshot functionality can be useful for providing visual context in context-aware transcription scenarios.
+</details>
+
 ### 5. Launch UtterType
 
 <details open>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mlx = ["lightning-whisper-mlx"]
+macos = ["mss", "Pillow"]
 
 [project.scripts]
 uttertype = "uttertype.main:run_app"

--- a/uttertype/context_screenshot.py
+++ b/uttertype/context_screenshot.py
@@ -101,3 +101,16 @@ def capture_active_window(max_dimension: int = 1200) -> Optional[Image.Image]:
     except Exception as e:
         print(f"Error capturing screenshot: {e}")
         return None
+
+
+if __name__ == "__main__":
+    # Test the functionality
+    if sys.platform == 'darwin':
+        img = capture_active_window(max_dimension=1600)  # Test with a smaller max dimension
+        if img:
+            print(f"Screenshot captured: {img.width}x{img.height}")
+            img.show()  # Display the image
+        else:
+            print("Failed to capture screenshot")
+    else:
+        print("This functionality is only available on macOS")

--- a/uttertype/context_screenshot.py
+++ b/uttertype/context_screenshot.py
@@ -1,0 +1,101 @@
+"""
+Active window screenshot capture for macOS.
+
+This module provides functionality to capture a screenshot of the currently active
+window on macOS systems. For other platforms, it will return None.
+
+Dependencies (install with optional 'macos' extra):
+- mss
+- Pillow
+"""
+
+import sys
+from typing import Optional
+
+# Import conditionally to avoid errors on non-macOS systems
+if sys.platform == 'darwin':
+    try:
+        from PIL import Image
+    except ImportError:
+        print("Pillow not installed. Install with: uv sync --extra macos")
+else:
+    # Define Image class for type hints on non-macOS
+    class Image:
+        class Image:
+            pass
+
+def capture_active_window() -> Optional[Image.Image]:
+    """
+    Capture a screenshot of the currently active window on macOS.
+    
+    Returns:
+        PIL Image object if successful, None otherwise or on non-macOS platforms.
+    """
+    # Check if we're on macOS
+    if sys.platform != 'darwin':
+        return None
+
+    try:
+        # Try to import the required libraries
+        try:
+            from mss import mss
+            # macOS-specific imports
+            from AppKit import NSWorkspace
+            from Quartz import CGWindowListCopyWindowInfo, kCGWindowListOptionOnScreenOnly, kCGNullWindowID
+        except ImportError as e:
+            print(f"Required dependency not available: {e}")
+            print("Install macOS dependencies with: uv sync --extra macos")
+            return None
+        
+        # Get active application
+        active_app = NSWorkspace.sharedWorkspace().activeApplication()
+        app_pid = active_app['NSApplicationProcessIdentifier']
+        
+        # Get information about the frontmost window
+        window_list = CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID)
+
+        # Find the frontmost window that belongs to our active application
+        target_window = None
+        for window in window_list:
+            if window.get('kCGWindowOwnerPID', 0) == app_pid:
+                # This window belongs to our active application
+                target_window = window
+                break
+
+        if target_window and 'kCGWindowBounds' in target_window:
+            # Extract window bounds
+            bounds = target_window['kCGWindowBounds']
+            left = bounds['X']
+            top = bounds['Y']
+            width = bounds['Width']
+            height = bounds['Height']
+
+            # Create monitor dict for mss
+            monitor = {"left": left, "top": top, "width": width, "height": height}
+        else:
+            # Could not find specific window, return None
+            return None
+            
+        # Take the screenshot using mss
+        with mss() as sct:
+            screenshot = sct.grab(monitor)
+            # Convert to PIL Image
+            img = Image.frombytes("RGB", screenshot.size, screenshot.bgra, "raw", "BGRX")
+            return img
+            
+    except Exception as e:
+        print(f"Error capturing screenshot: {e}")
+        return None
+
+
+if __name__ == "__main__":
+    # Test the functionality
+    if sys.platform == 'darwin':
+        img = capture_active_window()
+        if img:
+            print(f"Screenshot captured: {img.width}x{img.height}")
+            img.show()  # Display the image
+        else:
+            print("Failed to capture screenshot")
+    else:
+        print("This functionality is only available on macOS")

--- a/uttertype/context_screenshot.py
+++ b/uttertype/context_screenshot.py
@@ -24,12 +24,17 @@ else:
         class Image:
             pass
 
-def capture_active_window() -> Optional[Image.Image]:
+def capture_active_window(max_dimension: int = 1200) -> Optional[Image.Image]:
     """
     Capture a screenshot of the currently active window on macOS.
     
+    Args:
+        max_dimension: Maximum width or height of the returned image, preserving aspect ratio.
+                     Defaults to 1200 pixels.
+    
     Returns:
         PIL Image object if successful, None otherwise or on non-macOS platforms.
+        The image will be scaled down to fit within max_dimension while preserving aspect ratio.
     """
     # Check if we're on macOS
     if sys.platform != 'darwin':
@@ -81,21 +86,18 @@ def capture_active_window() -> Optional[Image.Image]:
             screenshot = sct.grab(monitor)
             # Convert to PIL Image
             img = Image.frombytes("RGB", screenshot.size, screenshot.bgra, "raw", "BGRX")
+            
+            # Resize the image if it's larger than max_dimension
+            width, height = img.size
+            if width > max_dimension or height > max_dimension:
+                # Calculate the scaling factor to preserve aspect ratio
+                scale_factor = min(max_dimension / width, max_dimension / height)
+                new_width = int(width * scale_factor)
+                new_height = int(height * scale_factor)
+                img = img.resize((new_width, new_height), Image.LANCZOS)
+                
             return img
             
     except Exception as e:
         print(f"Error capturing screenshot: {e}")
         return None
-
-
-if __name__ == "__main__":
-    # Test the functionality
-    if sys.platform == 'darwin':
-        img = capture_active_window()
-        if img:
-            print(f"Screenshot captured: {img.width}x{img.height}")
-            img.show()  # Display the image
-        else:
-            print("Failed to capture screenshot")
-    else:
-        print("This functionality is only available on macOS")


### PR DESCRIPTION
## Summary
- Added functionality to capture a screenshot of the active window on macOS
- Created a new `context_screenshot.py` module with a `capture_active_window()` function
- Added macOS-specific optional dependencies (mss, Pillow) to pyproject.toml

## Implementation Details
- Returns a PIL Image object if successful, None otherwise
- Gracefully handles non-macOS platforms by returning None
- Provides helpful error messages if dependencies are missing
- Uses AppKit and Quartz to identify the active window
- Uses mss for efficient screen capture

## Test plan
- Test on macOS to verify active window is captured correctly
- Verify behavior on non-macOS systems (should return None without errors)
- Test with missing dependencies to ensure helpful error messages

🤖 Generated with [Claude Code](https://claude.ai/code)